### PR TITLE
Allow calling setup() without arguments and support background option

### DIFF
--- a/lua/vercel/init.lua
+++ b/lua/vercel/init.lua
@@ -4,8 +4,9 @@ M.colors = require("vercel.colors").getColors("light")
 M.config = require("vercel.config")
 M.utils = require("vercel.utils")
 
----@param options Options
+---@param options table|nil Options
 function M.setup(options)
+	options = options or {}
 	setmetatable(M.config, { __index = vim.tbl_extend("force", M.config.defaults, options) })
 
 	M.colors = require("vercel.colors").getColors(M.config.theme)

--- a/lua/vercel/init.lua
+++ b/lua/vercel/init.lua
@@ -7,6 +7,11 @@ M.utils = require("vercel.utils")
 ---@param options table|nil Options
 function M.setup(options)
 	options = options or {}
+
+	if options.theme == nil then
+		options.theme = vim.opt.background:get()
+	end
+
 	setmetatable(M.config, { __index = vim.tbl_extend("force", M.config.defaults, options) })
 
 	M.colors = require("vercel.colors").getColors(M.config.theme)


### PR DESCRIPTION
Hey, thanks for making this theme available. I'd like to contribute back some small QoL changes from my fork. This is just small stuff that most other theme plugins I've used support.

## Allow calling setup() without arguments
It's kind of annoying that I *have* to pass an empty table to the setup function if I just want the defaults, so I added support for doing:
```lua
require('vercel').setup()
```
It also modifies the docstring to make the argument optional and get the LSP server to stop complaining.

## Add support for `vim.opt.background`
Most themes with light/dark variants I've used before support setting the `vim.opt.background` option to `light` or `dark` to toggle which variant will be used, so I added that.

Note that the old `config.theme` option still exists and takes priority.

None of these changes should break old configs since it's all optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically selects a theme based on Vim’s background when no theme is specified.

* **Bug Fixes**
  * Prevents errors during setup by defaulting options to an empty configuration.
  * Ensures consistent color configuration by merging defaults with user options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->