### PR TITLE
feat: auto detect color

### DIFF
--- a/lua/vercel/init.lua
+++ b/lua/vercel/init.lua
@@ -14,8 +14,6 @@ function M.setup(options)
 
 	setmetatable(M.config, { __index = vim.tbl_extend("force", M.config.defaults, options) })
 
-	M.colors = require("vercel.colors").getColors(M.config.theme)
-
 	M.highlights = { bufferline = {} }
 	M.highlights.bufferline = require("vercel.integrations.bufferline").highlights(M.config)
 end
@@ -29,6 +27,8 @@ function M.colorscheme()
 	vim.g.VM_theme_set_by_colorscheme = true
 	vim.o.termguicolors = true
 	vim.g.colors_name = "vercel"
+
+	M.colors = require("vercel.colors").getColors(M.config.theme or vim.opt.background:get())
 
 	M.set_terminal_colors()
 	M.set_groups()


### PR DESCRIPTION
if dont provide theme in config, auto detect theme in vim.opt.background and auto change theme when change vim.opt.background using cmd `:lua vim.opt.background=""`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the color palette is computed at colorscheme application, preventing mismatches that could occur at startup or when switching themes.
  * Fixes inconsistent terminal and highlight colors by falling back to the current background when no theme is set.

* **Improvements**
  * More reliable and predictable theming, with colors adapting correctly to the active theme or background.
  * Smoother experience when changing colorschemes, reducing visual glitches and ensuring consistent UI colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->